### PR TITLE
Refactor context

### DIFF
--- a/crates/polkakernel/src/machine.rs
+++ b/crates/polkakernel/src/machine.rs
@@ -115,6 +115,8 @@ pub trait Machine {
 
 	fn write_u64(&mut self, address: u64, value: u64) -> Result<(), MachineError>;
 	fn write_u32(&mut self, address: u64, value: u32) -> Result<(), MachineError>;
+	fn write_u16(&mut self, address: u64, value: u16) -> Result<(), MachineError>;
+	fn write_u8(&mut self, address: u64, value: u8) -> Result<(), MachineError>;
 	fn write_memory(&mut self, address: u64, slice: &[u8]) -> Result<(), MachineError>;
 }
 


### PR DESCRIPTION
Introduce `context` that implements all traits at once. This avoids using `RefCell` in the implementations. The PR also adds missing `write_u8` and `write_u16` functions.